### PR TITLE
Get full toc without spaming f5 when add several page with nav

### DIFF
--- a/syntax/toc.php
+++ b/syntax/toc.php
@@ -162,7 +162,7 @@ class syntax_plugin_docnavigation_toc extends DokuWiki_Syntax_Plugin {
                 $list[$pageid] = $item;
 
                 if(isset($options['includeheadings'])) {
-                    $toc = p_get_metadata($pageid, 'description tableofcontents', METADATA_RENDER_USING_CACHE);
+                    $toc = p_get_metadata($pageid, 'description tableofcontents', METADATA_RENDER_UNLIMITED);
 
                     if(is_array($toc)) foreach($toc as $tocitem) {
                         if($tocitem['level'] < $options['includeheadings'][0] || $tocitem['level'] > $options['includeheadings'][1]) {


### PR DESCRIPTION
When I create several page with navigation in a row (import script) then display the toc:
 - I get the warning  <doctoc> page X don't link back to Y.
 - The toc is partial.

I need to refresh several time the page to complete the toc and free the warnings (One refresh and one warning every 4 or 5 pages created).

This is because the depth to search into new navigation page is limited.