### PR TITLE
Toc - Add possibility to hide the page link

### DIFF
--- a/syntax/toc.php
+++ b/syntax/toc.php
@@ -159,7 +159,13 @@ class syntax_plugin_docnavigation_toc extends DokuWiki_Syntax_Plugin {
             $item['perm'] = auth_quickaclcheck($item['id']);
 
             if($item['perm'] >= AUTH_READ) {
-                $list[$pageid] = $item;
+
+                if(isset($options['hidepagelink']) == false) {
+                    $list[$pageid] = $item;
+                    $tocitemlevel = 2;
+                } else {
+                    $tocitemlevel = 1;
+                }
 
                 if(isset($options['includeheadings'])) {
                     $toc = p_get_metadata($pageid, 'description tableofcontents', METADATA_RENDER_USING_CACHE | METADATA_RENDER_UNLIMITED);
@@ -172,7 +178,7 @@ class syntax_plugin_docnavigation_toc extends DokuWiki_Syntax_Plugin {
                         $item['id'] = $pageid . '#' . $tocitem['hid'];
                         $item['ns'] = getNS($item['id']);
                         $item['type'] = 'heading';
-                        $item['level'] = 2 + $tocitem['level'] - $options['includeheadings'][0];
+                        $item['level'] = $tocitemlevel + $tocitem['level'] - $options['includeheadings'][0];
                         $item['title'] = $tocitem['title'];
 
                         $list[$item['id']] = $item;


### PR DESCRIPTION
I need to display a toc like a word document. I only want the title link.
I use the attribute includeheadings to get the titles included in the toc. Therefore The level 1 of the toc are page link. This code add the attribute hidepagelink which hide the page link.
<doctoc includeheadings=1-5, hidepagelink=1>